### PR TITLE
Test structure to JSON parsing added

### DIFF
--- a/src/TestRunner.jl
+++ b/src/TestRunner.jl
@@ -1,5 +1,5 @@
 module TestRunner
-export TestStructureNode,FactsNode,ContextNode,FactNode, get_tests_structure, children, json
+export TestStructureNode,FactsNode,ContextNode,FactNode, get_tests_structure, children, get_tests_structure_as_json
 import Base.==
 
 abstract TestStructureNode
@@ -85,6 +85,8 @@ end
 _get_tests_structure(testFileContent::Expr) =  testFileContent |> f
 
 get_tests_structure(testFilePath::AbstractString) = testFilePath |> get_file_content |> _get_tests_structure
+
+get_tests_structure_as_json(testFilePath::AbstractString) = testFilePath |> get_tests_structure |> json
 
 children(node::TestStructureNode) = isa(node, FactNode) ? Vector{TestStructureNode}() : node.children
 

--- a/src/TestRunner.jl
+++ b/src/TestRunner.jl
@@ -1,5 +1,5 @@
 module TestRunner
-export TestStructureNode,FactsNode,ContextNode,FactNode, get_tests_structure, children
+export TestStructureNode,FactsNode,ContextNode,FactNode, get_tests_structure, children, json
 import Base.==
 
 abstract TestStructureNode
@@ -88,4 +88,6 @@ get_tests_structure(testFilePath::AbstractString) = testFilePath |> get_file_con
 
 children(node::TestStructureNode) = isa(node, FactNode) ? Vector{TestStructureNode}() : node.children
 
-end # module
+include("TestRunnerJSON.jl")
+
+end # TestRunner module

--- a/src/TestRunnerJSON.jl
+++ b/src/TestRunnerJSON.jl
@@ -1,0 +1,38 @@
+using JSON
+
+function json(testStructureNodes::Array{TestRunner.TestStructureNode})
+  treeDictionary = [to_dict(node) for node in testStructureNodes]
+  JSON.json(treeDictionary)
+end
+
+function to_dict(factGroup::FactsNode)
+
+  childFactGroups = filter(child -> isa(child, TestRunner.FactsNode), factGroup.children)
+  childFacts = filter(child -> isa(child, TestRunner.FactNode), factGroup.children)
+  childContexts = filter(child -> isa(child, TestRunner.ContextNode), factGroup.children)
+
+  Dict(
+    "name" => factGroup.name,
+    "line" => factGroup.line,
+    "factGroups" => [to_dict(node) for node in childFactGroups],
+    "facts" => [to_dict(node) for node in childFacts],
+    "contexts" => [to_dict(node) for node in childContexts]
+  )
+end
+
+function to_dict(contextNode::ContextNode)
+  Dict(
+    "name" => contextNode.name,
+    "line" => contextNode.line,
+    "facts" => [to_dict(node) for node in contextNode.children]
+  )
+end
+
+function to_dict(factNode::FactNode)
+  Dict(
+    "name" => factNode.name,
+    "line" => factNode.line,
+    "result" => isnull(factNode.result)? nothing : get(factNode.result),
+    "details" => isnull(factNode.details)? nothing : get(factNode.details)
+  )
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+JSON

--- a/test/TestRunnerJSON.tests.jl
+++ b/test/TestRunnerJSON.tests.jl
@@ -1,0 +1,75 @@
+context("FactNode parsing") do
+
+  @fact TestRunner.to_dict(FactNode(18,"test name")) -->
+    Dict("name" => "test name", "line" => 18, "result" => nothing, "details" => nothing)
+
+  @fact TestRunner.to_dict(FactNode(18,"test name", Nullable{Bool}(true))) -->
+    Dict("name" => "test name", "line" => 18, "result" => true, "details" => nothing )
+
+  @fact TestRunner.to_dict(FactNode(18,"test name", Nullable{Bool}(false))) -->
+    Dict("name" => "test name", "line" => 18, "result" => false, "details" => nothing )
+
+  @fact TestRunner.to_dict(FactNode(18,"test name", Nullable{Bool}(false), "Test details")) -->
+    Dict("name" => "test name", "line" => 18, "result" => false, "details" => "Test details" )
+
+end
+
+context("FactsNode parsing") do
+  @fact TestRunner.to_dict(FactsNode(10,"some facts group", [])) -->
+    Dict(
+    "name" => "some facts group",
+    "line" => 10,
+    "facts" => [], "contexts" => [], "factGroups" => []
+    )
+
+  @fact TestRunner.to_dict(FactsNode(1,"fg", [FactNode(18,"test node")])) -->
+    Dict(
+    "facts" => [Dict("name" => "test node", "line" => 18, "result" => nothing, "details" => nothing)],
+    "name" => "fg","line" => 1,
+    "contexts" => [], "factGroups" => [])
+
+  @fact TestRunner.to_dict(FactsNode(1,"fg", [ContextNode(10,"Context name", [])])) -->
+    Dict(
+    "contexts" => [Dict("name" => "Context name", "line" => 10, "facts" => [])],
+    "name" => "fg", "line" => 1,
+    "facts" => [], "factGroups" => [])
+
+  @fact TestRunner.to_dict(FactsNode(1, "fg", [FactsNode(15, "Nested facts node", [])])) -->
+    Dict(
+    "factGroups" => [Dict("name" => "Nested facts node", "line" => 15, "facts" => [], "contexts" => [], "factGroups" => [])],
+    "name" => "fg", "line" => 1,
+    "contexts" => [], "facts" => []
+    )
+end
+
+context("ContextNode parsing") do
+
+  @fact TestRunner.to_dict(ContextNode(1, "some context node", [])) -->
+    Dict(
+    "name" => "some context node",
+    "line" => 1,
+    "facts" => []
+    )
+
+  @fact TestRunner.to_dict(ContextNode(1, "c", [FactNode(3,"fact node")])) -->
+    Dict(
+    "line" => 1,
+    "name" => "c",
+    "facts" => [Dict("name" => "fact node", "line" => 3, "result" => nothing, "details" => nothing)]
+    )
+end
+
+
+context("Tree to JSON parsing") do
+
+  sampleTestStructure = Vector{TestStructureNode}([
+     FactsNode(7,"First facts group",
+     [FactNode(8, "First group first test"),FactNode(9, "First group second failing test")]),
+     FactsNode(12,"Second facts group",
+     [FactNode(13,"Second group first test"),FactNode(14, "")]),
+     FactsNode(17,"",
+     [FactNode(18,""),FactNode(19,"")]),
+     FactsNode(21,"",[])
+   ])
+   
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,4 +49,8 @@ facts("Children function tests") do
   @pending children(FactsNode(17,"", [FactNode(18,""),FactNode(19,"")])) --> Vector{TestStructureNode}([FactNode(18,""),FactNode(19,"")])
 end
 
+facts("JSON parsing tests") do
+  include("TestRunnerJSON.tests.jl")
+end
+
 FactCheck.exitstatus()


### PR DESCRIPTION
Implementation is located in TestRunnerJSON.jl file and is included in package module
The tests are located in TestRunnerJSON.tests.jl file which is included in runtests.jl

The logic behind is quite simple: the test tree nodes are first converted to dictionaries and then parsed by external library (JSON.jl ,https://github.com/JuliaLang/JSON.jl ).
